### PR TITLE
Add nested() for python 3

### DIFF
--- a/six.py
+++ b/six.py
@@ -22,6 +22,7 @@
 
 from __future__ import absolute_import
 
+import contextlib
 import functools
 import itertools
 import operator
@@ -767,6 +768,16 @@ if sys.version_info[0:2] < (3, 4):
         return wrapper
 else:
     wraps = functools.wraps
+
+
+if PY3:
+    @contextlib.contextmanager
+    def nested(*contexts):
+        with contextlib.ExitStack() as stack:
+            yield [stack.enter_context(c) for c in contexts]
+else:
+    nested = contextlib.nested
+
 
 def with_metaclass(meta, *bases):
     """Create a base class with a metaclass."""


### PR DESCRIPTION
contextlib.nested() was deprecated in favour of the multiple manager form of the `with` statement. At the same time, `with` statement was added in python 2.5 (allowed when the with_statement feature has been enabled) and support for multiple context expressions from 2.7. 

Added a new `nested()` method to unify python codebase